### PR TITLE
🐛 avoid float precision comparison when foreign leverage almost equals local leverage

### DIFF
--- a/index.js
+++ b/index.js
@@ -243,7 +243,7 @@ const main = async () => {
     let toUpdate = false;
 
     // If leverage different, set to update
-    if (exchange.compo.leverage !== compositionToSet.leverage) {
+    if (exchange.compo.leverage.toFixed(2) !== compositionToSet.leverage.toFixed(2)) {
       console.log('=> Leverage is different');
       toUpdate = true;
     }


### PR DESCRIPTION
This PR aims to resolve useless requests I do when my leverage is about 1.50, and foreign leverage is saved as 1.4999999999...

I don't know why my leverage is not fully saved as I specifies it.